### PR TITLE
Adding cli to dump header, XML data or boot metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,20 @@ Header {
   reserved: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00  ... >
 }
 ```
+
+### CLI Usage
+```
+npx wim wimfile -h|-x|-m
+  dump wimfile header, xml data or metadata
+```
+
+### CLI - read version from windows installation ISO 
+
+ISO mount on filesystem is Linux-specific here.
+
+```
+mount win10.iso /mnt/win10/ -o loop
+npx wim /mnt/win10/sources/install.wim -x | npx --package @toycode/xml2json-cli xml2json | jq -r .WIM.IMAGE[0].WINDOWS[0].SERVICINGDATA[0].PKEYCONFIGVERSION[0]
+```
+
+You get `10.0.19041.1202;2016-01-01T00:00:00Z` for instance.

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+var WIM = require( './lib/wim' )
+var image = new WIM.Image()
+ 
+if (process.argv.length < 4) {
+    console.log('npx wim wimfile -h|-x|-m')
+    console.log('  dump wimfile header, xml data or metadata')
+    process.exit(-1)
+}
+
+function handleError(error) {
+    console.error(error);
+    process.exit(-1)
+}
+
+image.open( process.argv[2], function( error ) {
+  if( error ) return handleError( error )
+  image.readHeader( function( error, header ) {
+    if (process.argv[3] === '-h') {
+      console.log( header )
+    }
+    if (process.argv[3] === '-x') {
+        image.readXmlData( function( error, header ) {
+            console.log( header )
+        })
+    }
+    if (process.argv[3] === '-m') {
+        image.readMetadata( function( error, header ) {
+            console.log( header )
+        })
+    }
+  })
+})

--- a/lib/file-header.js
+++ b/lib/file-header.js
@@ -55,12 +55,12 @@ FileHeader.prototype = {
     offset = offset || 0
 
     // _RESHDR_BASE_DISK
-    this.size = buffer.readUIntLE( offset + 0, 7 )
+    this.size = buffer.readUIntLE( offset + 0, 6 ) + (1<<6)*buffer.readUIntLE( offset + 6, 1 )
     this.flags = buffer.readUInt8( offset + 7 )
-    this.offset = buffer.readIntLE( offset + 8, 8 )
+    this.offset = Number(buffer.readBigInt64LE( offset + 8 ))
 
     // _RESHDR_DISK_SHORT
-    this.originalSize = buffer.readIntLE( offset + 16, 8 )
+    this.originalSize = Number(buffer.readBigInt64LE( offset + 16 ))
 
     return this
 

--- a/lib/header.js
+++ b/lib/header.js
@@ -16,7 +16,7 @@ function Header() {
   this.version = 0x00000000
   this.flags = 0x00000000
   this.compressedSize = 0x00000000
-  this.guid = new Buffer(16)
+  this.guid = Buffer.alloc(16)
   this.partNumber = 0x0001
   this.partCount = 0x0000
   this.imageCount = 0x00000000
@@ -25,7 +25,7 @@ function Header() {
   this.bootMetadata = new WIM.FileResource.Header()
   this.bootIndex = 0x00000000
   this.integrity = new WIM.FileResource.Header()
-  this.reserved = new Buffer(60)
+  this.reserved = Buffer.alloc(60)
 
   this.guid.fill(0)
   this.reserved.fill(0)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "format"
   ],
   "main": "lib/wim.js",
+  "bin": {
+    "wim": "cli.js"
+  },
   "dependencies": {},
   "devDependencies": {
     "mocha": "~3.2.0"


### PR DESCRIPTION
Hi !

I've patched the project on Buffer, it seems the API changed since 5 years ago (?)

But mostly I added a cli, to dump version of windows ISO, for instance. I've written about that in the README.

It's an old project, but could you publish a 0.1.1 with that maybe? :)